### PR TITLE
Apply #18456 Fix controlled TextInput for Chinese (and other languages)

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
@@ -25,6 +25,7 @@
   NSAttributedString *_Nullable _localAttributedText;
   CGSize _previousContentSize;
 
+  NSString *_text;
   NSTextStorage *_textStorage;
   NSTextContainer *_textContainer;
   NSLayoutManager *_layoutManager;
@@ -95,6 +96,17 @@
     },
     @"target": self.reactTag,
   });
+}
+
+- (NSString *)text
+{
+  return _text;
+}
+
+- (void)setText:(NSString *)text
+{
+  _text = text;
+  _previousAttributedText = _localAttributedText;
 }
 
 #pragma mark - RCTUIManagerObserver

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -311,7 +311,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
   _nativeEventCount++;
 
-  if (_onChange) {
+  if (_onChange && backedTextInputView.markedTextRange == nil) {
     _onChange(@{
        @"text": self.attributedText.string,
        @"target": self.reactTag,


### PR DESCRIPTION
Apply [#18456]() to fix TextInput bugs.
**This PR is for `0.54-stable-flow-0.66` branch**

Related Issues at react-native:
- [TextInput.setNativeProps({text: ''}) no longer works](https://github.com/facebook/react-native/issues/18272)
- [Controlled TextInput broken for Chinese (and other languages) in v0.54 on iOS](https://github.com/facebook/react-native/issues/18403)
